### PR TITLE
Better readability on light theme

### DIFF
--- a/assets/config.yml
+++ b/assets/config.yml
@@ -24,7 +24,7 @@ colors:
     text-subtitle: "#111111"
     card-shadow: rgba(0, 0, 0, 0.5)
     link: "#3273dc"
-    link-hover: "#c1c1c1"
+    link-hover: "#2e4053"
     background-image: "../assets/wallpaper-light.jpeg" # Change wallpaper.jpeg to the name of your own custom wallpaper!
   dark:
     highlight-primary: "#181C3A"


### PR DESCRIPTION
On light theme, hover an item isn't enough contrasted : 
![image](https://user-images.githubusercontent.com/89610869/137811391-027517a8-3706-49a7-aa8a-e518d1f8e7de.png)

Solution (feel free to adjust) : 
![image](https://user-images.githubusercontent.com/89610869/137811354-7152753e-edd6-4c90-98bc-f5f355a1f05a.png)
